### PR TITLE
Untested Ready Labeling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jira-client": "^6.1.1",
     "jsonwebtoken": "^8.1.0",
     "markdown2confluence-cws": "^2.0.2",
-    "marked": "^0.3.6",
+    "marked": "^0.3.9",
     "moment": "^2.18.1",
     "nconf": "^0.8.4",
     "read-dir-files": "^0.1.1",


### PR DESCRIPTION
This PR fixes a bug where transitioning an issue to `Ready` would fail when the issue had not been tested. Now, the label is removed and a comment left on the PR, just like when the PR is not mergable.